### PR TITLE
Use CDN links for passed-ci RDO repos

### DIFF
--- a/tasks/undercloud-setup-repos-passed-ci.yml
+++ b/tasks/undercloud-setup-repos-passed-ci.yml
@@ -1,12 +1,12 @@
 ---
 - get_url:
-    url: http://buildlogs.centos.org/centos/7/cloud/x86_64/rdo-trunk-master-tripleo/delorean.repo
+    url: https://trunk.rdoproject.org/centos7-master/current-passed-ci/delorean.repo
     dest: /etc/yum.repos.d/delorean.repo
   tags:
     - setup
 
 - get_url:
-    url: http://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
+    url: https://trunk.rdoproject.org/centos7/current/delorean.repo
     dest: /etc/yum.repos.d/delorean-current.repo
   tags:
     - setup


### PR DESCRIPTION
This matches upstream TripleO documentation.